### PR TITLE
Fix typos in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 
 ## Overview
 
-PositiveFactorizations is a package for computing a positive-definite
+PositiveFactorizations is a package for computing a positive definite
 matrix decomposition (factorization) from an arbitrary symmetric
 input.  The motivating application is optimization (Newton or
-quasi-Newton methods), in which the cannonical search direction `-H\g`
+quasi-Newton methods), in which the canonical search direction `-H\g`
 (`H` being the Hessian and `g` the gradient) may not be a descent
 direction if `H` is not positive definite.  This package provides an
 efficient approach to computing `-Htilde\g`, where `Htilde` is equal
-to `H` if `H` is positive-definite, and otherwise is a
-positive-definite matrix that is "spiritually like `H`."
+to `H` if `H` is positive definite, and otherwise is a
+positive definite matrix that is "spiritually like `H`."
 
 The approach favored here is different from the well-known
 Gill-Murray-Wright approach of computing the Cholesky factorization of


### PR DESCRIPTION
- cannonical -> canonical

- positive-definite matrix -> positive definite matrix, by far the [more common orthography](https://books.google.com/ngrams/graph?content=positive-definite+matrix%2Cpositive+definite+matrix&year_start=1900&year_end=2008&corpus=15&smoothing=3&share=&direct_url=t1%3B%2Cpositive%20-%20definite%20matrix%3B%2Cc0%3B.t1%3B%2Cpositive%20definite%20matrix%3B%2Cc0)