### PR TITLE
test against both 0.4 and 0.5 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
0.4 still supported accordong to REQUIRE