### PR TITLE
remove (removed) scale function

### DIFF
--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -230,7 +230,7 @@ end
 # Computes dest -= C*diagm(d)*C', in the lower diagonal
 function update_columns!(dest, d::AbstractVector, C::AbstractMatrix)
     Ct = C'
-    Cdt = scale(d, Ct)
+    Cdt = Diagonal(d) * Ct
     K = size(dest, 1)
     nc = size(C, 2)
     for j = 1:K

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,11 @@ for pivot in (Val{false}, Val{true})
     F, d = ldlt(Positive, A, pivot)
     @test Matrix(F) ≈ A
     @test all(d .== 1)
+
+    # factorization of (not too small) BigFloat matrices passes
+    a = BigFloat.(1:15); A = a * a'
+    F = cholesky(Positive, A, pivot)
+    F, d = ldlt(Positive, A, pivot)
 end
 
 A = [1 0; 0 -2]


### PR DESCRIPTION
I ran into an issue using `BigFloat` matrices of size 15 × 15 or bigger, since the `scale` function has been removed, cf. https://github.com/JuliaLang/julia/issues/12945. I've updated the code of PositiveFactorizations accordingly and added a test where this problem showed up.